### PR TITLE
Fix EnvVar resolution for class-based configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ uv run python scratch/demo_v3.py 42
 ## Installation
 
 ```bash
-pip install params-proto
+pip install params-proto==3.0.0-rc4
 ```
 
 ## Key Features

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,8 +13,8 @@ messages.
 Here is a quick example: first install params-proto using uv or pip
 
 ```shell
-uv add params-proto  # or
-pip install params-proto
+uv add params-proto==3.0.0-rc4  # or
+pip install params-proto==3.0.0-rc4
 ```
 
 Now you can convert this function into a CLI program:

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -3,12 +3,12 @@
 Get started with params-proto v3 in 10 minutes!
 
 ```bash
-pip install params-proto
+pip install params-proto==3.0.0-rc4
 ```
 
 Or with uv:
 ```bash
-uv add params-proto
+uv add params-proto==3.0.0-rc4
 ```
 
 ## Your First Proto Function CLI

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -2,6 +2,17 @@
 
 This page contains the release history and changelog for params-proto.
 
+## Version 3.0.0-rc4 (2025-12-14)
+
+### 🐛 Bug Fixes
+
+- **EnvVar Class Resolution**: Fixed EnvVar not resolving at import time for class-based configs.
+  Previously, accessing `Config.ip` on a `@proto.prefix` class with `ip: str = EnvVar @ "VAR" | "default"`
+  would return the `EnvVar` object instead of the resolved value. Now EnvVar values are resolved at
+  decoration time for both functions and classes.
+
+---
+
 ## Version 3.0.0 (Upcoming)
 
 ### 🎉 Major Release: Complete v3 Redesign

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "params-proto"
-version = "3.0.0-rc3"
+version = "3.0.0-rc4"
 description = "Modern Hyper Parameter Management for Machine Learning"
 authors = [
     { name = "Ge Yang" }


### PR DESCRIPTION
## Summary
- Fixed EnvVar not resolving at import time for class-based configs (`@proto` and `@proto.prefix`)
- Previously, accessing `Config.ip` on a `@proto.prefix` class with `ip: str = EnvVar @ "VAR" | "default"` would return the `EnvVar` object instead of the resolved value
- The issue was that `_EnvVar` has `__call__`, causing `callable(value)` to return True, skipping the resolution logic

## Changes
- Check for EnvVar instances before the callable check in `proto()` decorator
- Added tests for class-based EnvVar resolution
- Bumped version to 3.0.0-rc4
- Updated docs to pip install the new version

## Test plan
- [x] Run `pytest tests/test_v3/test_proto_envvar.py` - all 14 tests pass
- [x] Run full test suite - 291 passed (2 pre-existing failures unrelated to this change)
- [x] Verified EnvVar resolution works for both functions and classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolve EnvVar at decoration time for class-based configs with proper type conversion; add tests, bump to 3.0.0-rc4, and update docs/install instructions.
> 
> - **Core (proto)**:
>   - Resolve `EnvVar` for class-based configs in `proto()` by checking for `_EnvVar` before `callable()` and converting via `_convert_type` using `dtype` or annotation.
> - **Tests**:
>   - Add class-based `EnvVar` tests, including type conversion and `@proto.prefix` attribute access (`tests/test_v3/test_proto_envvar.py`).
> - **Docs**:
>   - Update install snippets to `params-proto==3.0.0-rc4` in `README.md`, `docs/index.md`, `docs/quick_start.md`.
>   - Add release notes entry for `3.0.0-rc4` with bug fix details (`docs/release_notes.md`).
> - **Versioning**:
>   - Bump version to `3.0.0-rc4` in `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93bcc4c6655a7987dda75ccaf19820add01f4603. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->