### PR TITLE
Add Claude skill for params-proto

### DIFF
--- a/.claude/skills/params-proto/api/proto-cli.md
+++ b/.claude/skills/params-proto/api/proto-cli.md
@@ -1,0 +1,191 @@
+# @proto.cli Decorator
+
+The `@proto.cli` decorator creates CLI entry points from functions or classes.
+
+## Basic Usage
+
+```python
+from params_proto import proto
+
+@proto.cli
+def train(
+    lr: float = 0.001,  # Learning rate
+    batch_size: int = 32,  # Batch size
+    epochs: int = 100,  # Training epochs
+):
+    """Train a neural network."""
+    print(f"Training with lr={lr}, batch={batch_size}, epochs={epochs}")
+
+if __name__ == "__main__":
+    train()
+```
+
+## Parameters
+
+### `prog` - Override Program Name
+
+```python
+@proto.cli(prog="my-trainer")
+def train(lr: float = 0.001): ...
+```
+
+Help shows `usage: my-trainer` instead of filename.
+
+## CLI Argument Parsing
+
+### Named Arguments
+
+```bash
+python train.py --lr 0.01 --batch-size 64
+```
+
+- Underscores in Python → hyphens in CLI
+- `learning_rate` → `--learning-rate`
+
+### Positional Arguments (Required Params)
+
+```python
+@proto.cli
+def train(
+    seed: int,  # Required - no default
+    lr: float = 0.001,
+): ...
+```
+
+```bash
+python train.py 42  # seed as positional
+python train.py --seed 42  # or named
+```
+
+### Boolean Flags
+
+```python
+@proto.cli
+def train(
+    verbose: bool = False,  # Use --verbose to enable
+    cuda: bool = True,  # Use --no-cuda to disable
+): ...
+```
+
+- `default=False` → `--flag` sets True
+- `default=True` → `--no-flag` sets False
+
+Help text shows appropriate form:
+```
+--verbose BOOL       Enable verbose (default: False)
+--no-cuda BOOL       Use CUDA (default: True)
+```
+
+## Help Text Generation
+
+### From Inline Comments
+
+```python
+@proto.cli
+def train(
+    lr: float = 0.001,  # Learning rate for optimizer
+): ...
+```
+
+### From Docstrings
+
+```python
+@proto.cli
+def train(lr: float = 0.001):
+    """Train a model.
+
+    Args:
+        lr: Learning rate for the optimizer
+    """
+```
+
+### Combined (Multi-line)
+
+```python
+@proto.cli
+def train(
+    lr: float = 0.001,  # Learning rate
+):
+    """Train a model.
+
+    Args:
+        lr: Controls gradient step size
+    """
+```
+
+Output:
+```
+--lr FLOAT    Learning rate
+              Controls gradient step size (default: 0.001)
+```
+
+## Programmatic Calls
+
+When called with arguments, CLI parsing is bypassed:
+
+```python
+@proto.cli
+def train(lr: float = 0.001): ...
+
+# These bypass sys.argv parsing:
+train(lr=0.01)
+train(0.01)
+```
+
+## With @proto.prefix Classes
+
+`@proto.cli` automatically picks up `@proto.prefix` singletons:
+
+```python
+@proto.prefix
+class Model:
+    name: str = "resnet"
+
+@proto.cli
+def train(seed: int = 42):
+    print(f"Training {Model.name}")
+
+if __name__ == "__main__":
+    train()
+```
+
+```bash
+python train.py --model.name vit --seed 123
+```
+
+## Error Handling
+
+### Missing Required Arguments
+
+```bash
+$ python train.py
+error: the following argument is required: seed
+```
+
+### Invalid Values
+
+```bash
+$ python train.py --lr not-a-number
+error: invalid value for --lr: not-a-number
+```
+
+### Unknown Arguments
+
+```bash
+$ python train.py --unknown-arg 123
+error: unrecognized argument: --unknown-arg
+```
+
+## Exit Codes
+
+- `0` - Success or `--help`
+- `1` - Argument parsing error
+- Other - From your function
+
+## Best Practices
+
+1. **Always use type hints** - Required for CLI parsing
+2. **Add inline comments** - Become help text
+3. **Use descriptive docstrings** - Become CLI description
+4. **Group related params** - Use `@proto.prefix` for organization
+5. **Test with `--help`** - Verify help text is clear

--- a/.claude/skills/params-proto/api/proto-prefix.md
+++ b/.claude/skills/params-proto/api/proto-prefix.md
@@ -1,0 +1,200 @@
+# @proto.prefix Decorator
+
+The `@proto.prefix` decorator creates singleton configuration classes with namespaced CLI arguments.
+
+## Basic Usage
+
+```python
+from params_proto import proto
+
+@proto.prefix
+class Training:
+    """Training hyperparameters."""
+    lr: float = 0.001  # Learning rate
+    batch_size: int = 32  # Batch size
+    epochs: int = 100  # Number of epochs
+
+# Access as class attributes (singleton)
+print(Training.lr)  # 0.001
+Training.lr = 0.01  # Direct modification
+```
+
+## With @proto.cli
+
+`@proto.prefix` classes automatically integrate with `@proto.cli`:
+
+```python
+@proto.prefix
+class Model:
+    """Model configuration."""
+    name: str = "resnet50"
+    dropout: float = 0.5
+
+@proto.prefix
+class Training:
+    """Training hyperparameters."""
+    lr: float = 0.001
+    epochs: int = 100
+
+@proto.cli
+def main(seed: int = 42):
+    """Train with configuration."""
+    print(f"Training {Model.name} with lr={Training.lr}")
+
+if __name__ == "__main__":
+    main()
+```
+
+### CLI Syntax
+
+```bash
+# Prefix.param-name syntax
+python train.py --model.name vit --training.lr 0.01
+
+# Help shows grouped options
+python train.py --help
+```
+
+### Help Output
+
+```
+usage: train.py [-h] [--seed INT] [OPTIONS]
+
+Train with configuration.
+
+options:
+  -h, --help           show this help message and exit
+  --seed INT           Random seed (default: 42)
+
+Model options:
+  Model configuration.
+
+  --model.name STR     Model name (default: resnet50)
+  --model.dropout FLOAT
+                       Dropout rate (default: 0.5)
+
+Training options:
+  Training hyperparameters.
+
+  --training.lr FLOAT  Learning rate (default: 0.001)
+  --training.epochs INT
+                       Number of epochs (default: 100)
+```
+
+## Singleton Behavior
+
+`@proto.prefix` creates a **singleton** - there's only one instance:
+
+```python
+@proto.prefix
+class Config:
+    value: int = 0
+
+# All access the same singleton
+Config.value = 42
+print(Config.value)  # 42
+
+# Even "instances" share state
+c1 = Config()
+c2 = Config()
+c1.value = 100
+print(c2.value)  # 100
+print(Config.value)  # 100
+```
+
+## Override Patterns
+
+### 1. Direct Assignment
+
+```python
+Training.lr = 0.01
+Training.epochs = 200
+```
+
+### 2. CLI Arguments
+
+```bash
+python train.py --training.lr 0.01 --training.epochs 200
+```
+
+### 3. Context Manager
+
+```python
+with proto.bind(Training, lr=0.01, epochs=200):
+    # Training.lr == 0.01 inside this block
+    train()
+# Training.lr restored to original after block
+```
+
+### 4. Multiple Bindings
+
+```python
+with proto.bind(Training, lr=0.01), proto.bind(Model, name="vit"):
+    train()
+```
+
+## Boolean Flags in Prefix
+
+```python
+@proto.prefix
+class Config:
+    verbose: bool = False  # --config.verbose to enable
+    cuda: bool = True  # --no-config.cuda to disable
+```
+
+## Naming Convention
+
+- Class name → lowercase prefix in CLI
+- `class Training:` → `--training.param`
+- `class ModelConfig:` → `--modelconfig.param`
+
+## Multiple Prefix Classes
+
+```python
+@proto.prefix
+class Data:
+    path: str = "./data"
+    workers: int = 4
+
+@proto.prefix
+class Model:
+    name: str = "resnet"
+    layers: int = 50
+
+@proto.prefix
+class Optimizer:
+    name: str = "adam"
+    lr: float = 0.001
+
+@proto.cli
+def train():
+    print(f"Data: {Data.path}")
+    print(f"Model: {Model.name}")
+    print(f"Optimizer: {Optimizer.name}, lr={Optimizer.lr}")
+```
+
+## vs @proto
+
+| Feature | `@proto.prefix` | `@proto` |
+|---------|-----------------|----------|
+| Singleton | Yes | No |
+| CLI integration | Auto with `@proto.cli` | Manual |
+| Access pattern | `Class.attr` | `instance.attr` |
+| Multiple instances | No | Yes |
+
+Use `@proto.prefix` for:
+- Global configuration
+- Multi-namespace CLI apps
+- Shared state across modules
+
+Use `@proto` for:
+- Reusable config templates
+- Multiple config instances
+- Library code
+
+## Best Practices
+
+1. **Group related params** - One class per logical group
+2. **Use docstrings** - Become section descriptions in help
+3. **Keep names short** - `Model` not `ModelConfiguration`
+4. **Document with comments** - Each param gets help text

--- a/.claude/skills/params-proto/api/types.md
+++ b/.claude/skills/params-proto/api/types.md
@@ -1,0 +1,226 @@
+# Type Annotations
+
+params-proto uses type hints for CLI parsing and help generation.
+
+## Basic Types
+
+```python
+@proto.cli
+def example(
+    count: int = 10,      # INT in help
+    rate: float = 0.5,    # FLOAT in help
+    name: str = "default",  # STR in help
+    enabled: bool = True,  # BOOL in help
+): ...
+```
+
+## Boolean Handling
+
+```python
+@proto.cli
+def train(
+    verbose: bool = False,  # --verbose BOOL (to enable)
+    cuda: bool = True,      # --no-cuda BOOL (to disable)
+): ...
+```
+
+- `default=False` → help shows `--flag`
+- `default=True` → help shows `--no-flag`
+
+CLI usage:
+```bash
+python train.py --verbose     # verbose=True
+python train.py --no-cuda     # cuda=False
+```
+
+## Optional Types
+
+```python
+from typing import Optional
+
+@proto.cli
+def process(
+    config: str | None = None,  # Python 3.10+
+    path: Optional[str] = None,  # typing.Optional
+): ...
+```
+
+## Union Types
+
+### Simple Unions
+
+```python
+@proto.cli
+def train(
+    lr: int | float = 0.001,  # Accepts either
+    seed: int | None = None,  # Optional int
+): ...
+```
+
+### Dataclass Unions (Subcommand Pattern)
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class Adam:
+    lr: float = 0.001
+    beta1: float = 0.9
+
+@dataclass
+class SGD:
+    lr: float = 0.01
+    momentum: float = 0.9
+
+@proto.cli
+def train(optimizer: Adam | SGD):
+    """First positional arg selects type."""
+    print(f"Using {type(optimizer).__name__}")
+```
+
+```bash
+python train.py adam --lr 0.001
+python train.py sgd --momentum 0.95
+```
+
+Class names are converted to kebab-case:
+- `PerspectiveCamera` → `perspective-camera`
+- `HTTPServer` → `http-server`
+
+## Literal Types
+
+```python
+from typing import Literal
+
+@proto.cli
+def train(
+    optimizer: Literal["adam", "sgd", "rmsprop"] = "adam",
+    precision: Literal[16, 32, 64] = 32,
+): ...
+```
+
+Help shows: `--optimizer VALUE` with choices documented.
+
+## Enum Types
+
+```python
+from enum import Enum
+
+class Optimizer(Enum):
+    ADAM = "adam"
+    SGD = "sgd"
+    RMSPROP = "rmsprop"
+
+@proto.cli
+def train(
+    optimizer: Optimizer = Optimizer.ADAM,
+): ...
+```
+
+Help shows: `--optimizer {ADAM,SGD,RMSPROP}`
+
+CLI usage:
+```bash
+python train.py --optimizer SGD
+```
+
+## Collection Types
+
+### List
+
+```python
+from typing import List
+
+@proto.cli
+def process(
+    files: List[str] = ["input.txt"],
+    dims: List[int] = [128, 256],
+): ...
+```
+
+```bash
+python process.py --files a.txt b.txt c.txt
+python process.py --dims 512 1024
+```
+
+### Tuple
+
+```python
+from typing import Tuple
+
+@proto.cli
+def train(
+    image_size: Tuple[int, int] = (224, 224),
+): ...
+```
+
+```bash
+python train.py --image-size 256 256
+```
+
+## Path Types
+
+```python
+from pathlib import Path
+
+@proto.cli
+def process(
+    input_dir: Path = Path("./data"),
+    output: Path = Path("output.txt"),
+): ...
+```
+
+Strings automatically converted to `Path` objects.
+
+## Type Display in Help
+
+| Python Type | CLI Display |
+|-------------|-------------|
+| `int` | `INT` |
+| `float` | `FLOAT` |
+| `str` | `STR` |
+| `bool` | `BOOL` |
+| `Enum` | `{MEMBER1,MEMBER2,...}` |
+| Other | `VALUE` |
+
+## Required vs Optional
+
+```python
+@proto.cli
+def train(
+    # Required: no default, type must be callable
+    config: Params,
+
+    # Optional: has default
+    epochs: int = 100,
+): ...
+```
+
+Required parameters:
+- Show `(required)` in help
+- Can be passed positionally
+- Type hint is **called** to instantiate
+
+## Type Conversion
+
+Values from CLI are automatically converted:
+
+```python
+@proto.cli
+def train(
+    lr: float = 0.001,  # "0.01" → 0.01
+    epochs: int = 100,  # "50" → 50
+    debug: bool = False,  # flag → True
+): ...
+```
+
+Boolean string conversion:
+- True: `"true"`, `"1"`, `"yes"`, `"on"`
+- False: `"false"`, `"0"`, `"no"`, `"off"`
+
+## Best Practices
+
+1. **Be specific** - Use `Literal` or `Enum` over `str` when possible
+2. **Use Optional explicitly** - `str | None` not `str = None`
+3. **Document constraints** - In comments: `# Learning rate (0, 1)`
+4. **Prefer Enum for fixed sets** - Better IDE support and validation

--- a/.claude/skills/params-proto/examples/patterns.md
+++ b/.claude/skills/params-proto/examples/patterns.md
@@ -1,0 +1,261 @@
+# Common Patterns
+
+## Simple Training Script
+
+```python
+from params_proto import proto
+
+@proto.cli
+def train(
+    lr: float = 0.001,  # Learning rate
+    batch_size: int = 32,  # Batch size
+    epochs: int = 100,  # Training epochs
+    seed: int = 42,  # Random seed
+):
+    """Train a model."""
+    print(f"Training for {epochs} epochs with lr={lr}")
+
+if __name__ == "__main__":
+    train()
+```
+
+## Multi-Namespace ML Config
+
+```python
+from params_proto import proto
+
+@proto.prefix
+class Data:
+    """Data configuration."""
+    path: str = "./data"  # Data directory
+    batch_size: int = 32  # Batch size
+    workers: int = 4  # Data loader workers
+
+@proto.prefix
+class Model:
+    """Model configuration."""
+    name: str = "resnet50"  # Architecture
+    pretrained: bool = True  # Use pretrained weights
+    dropout: float = 0.5  # Dropout rate
+
+@proto.prefix
+class Training:
+    """Training hyperparameters."""
+    lr: float = 0.001  # Learning rate
+    epochs: int = 100  # Number of epochs
+    weight_decay: float = 1e-4  # L2 regularization
+
+@proto.cli
+def main(
+    seed: int = 42,  # Random seed
+    device: str = "cuda",  # Device (cuda/cpu)
+):
+    """Train image classifier."""
+    print(f"Model: {Model.name}")
+    print(f"Data: {Data.path}")
+    print(f"Training: lr={Training.lr}, epochs={Training.epochs}")
+
+if __name__ == "__main__":
+    main()
+```
+
+## Environment-Based Config
+
+```python
+from params_proto import proto, EnvVar
+
+@proto.prefix
+class Database:
+    host: str = EnvVar @ "DB_HOST" | "localhost"
+    port: int = EnvVar @ "DB_PORT" | 5432
+    user: str = EnvVar @ "DB_USER" | "postgres"
+    password: str = EnvVar @ "DB_PASSWORD"
+    name: str = EnvVar @ "DB_NAME" | "myapp"
+
+@proto.prefix
+class API:
+    key: str = EnvVar @ "API_KEY"
+    base_url: str = EnvVar @ "API_URL" | "https://api.example.com"
+
+@proto.cli
+def serve(
+    port: int = EnvVar @ "PORT" | 8080,
+    debug: bool = EnvVar @ "DEBUG" | False,
+):
+    """Start the server."""
+    print(f"Connecting to {Database.host}:{Database.port}")
+    print(f"Serving on port {port}")
+```
+
+## Union Types (Subcommand-like)
+
+```python
+from dataclasses import dataclass
+from params_proto import proto
+
+@dataclass
+class Train:
+    """Training mode."""
+    lr: float = 0.001
+    epochs: int = 100
+    batch_size: int = 32
+
+@dataclass
+class Evaluate:
+    """Evaluation mode."""
+    checkpoint: str = "model.pt"
+    batch_size: int = 64
+
+@dataclass
+class Export:
+    """Export mode."""
+    checkpoint: str = "model.pt"
+    format: str = "onnx"
+
+@proto.cli
+def main(mode: Train | Evaluate | Export):
+    """ML pipeline with different modes."""
+    if isinstance(mode, Train):
+        print(f"Training: lr={mode.lr}, epochs={mode.epochs}")
+    elif isinstance(mode, Evaluate):
+        print(f"Evaluating: {mode.checkpoint}")
+    elif isinstance(mode, Export):
+        print(f"Exporting to {mode.format}")
+
+if __name__ == "__main__":
+    main()
+```
+
+```bash
+python main.py train --lr 0.01 --epochs 50
+python main.py evaluate --checkpoint best.pt
+python main.py export --format torchscript
+```
+
+## Hyperparameter Sweep
+
+```python
+from params_proto import proto, Sweep
+
+@proto.cli
+def train(
+    lr: float = 0.001,
+    batch_size: int = 32,
+    model: str = "resnet50",
+    seed: int = 42,
+):
+    """Train with given hyperparameters."""
+    print(f"Training {model} with lr={lr}, batch={batch_size}, seed={seed}")
+    # Return metrics for logging
+    return {"accuracy": 0.95, "loss": 0.1}
+
+# Run sweep
+sweep = Sweep(train).product(
+    lr=[0.001, 0.01],
+    batch_size=[32, 64],
+    model=["resnet50", "vit"],
+).set(
+    seed=42,
+)
+
+results = []
+for config in sweep:
+    metrics = train(**config)
+    results.append({**config, **metrics})
+```
+
+## Context Manager Overrides
+
+```python
+from params_proto import proto
+
+@proto.prefix
+class Config:
+    lr: float = 0.001
+    debug: bool = False
+
+def train():
+    print(f"lr={Config.lr}, debug={Config.debug}")
+
+# Default values
+train()  # lr=0.001, debug=False
+
+# Override with context manager
+with proto.bind(Config, lr=0.01, debug=True):
+    train()  # lr=0.01, debug=True
+
+# Back to defaults
+train()  # lr=0.001, debug=False
+```
+
+## Reusable Config Class
+
+```python
+from params_proto import proto
+
+@proto
+class OptimizerConfig:
+    """Reusable optimizer configuration."""
+    name: str = "adam"
+    lr: float = 0.001
+    weight_decay: float = 1e-4
+
+# Create multiple instances
+adam_config = OptimizerConfig(name="adam", lr=0.001)
+sgd_config = OptimizerConfig(name="sgd", lr=0.01)
+
+# Use in training
+def train(optimizer_config: OptimizerConfig):
+    print(f"Using {optimizer_config.name} with lr={optimizer_config.lr}")
+```
+
+## CLI with Validation
+
+```python
+from params_proto import proto
+from enum import Enum
+
+class Precision(Enum):
+    FP32 = "fp32"
+    FP16 = "fp16"
+    BF16 = "bf16"
+
+@proto.cli
+def train(
+    lr: float = 0.001,  # Learning rate (0, 1)
+    batch_size: int = 32,  # Batch size (power of 2)
+    precision: Precision = Precision.FP32,  # Training precision
+):
+    """Train with validation."""
+    # Validate
+    if not 0 < lr < 1:
+        raise ValueError(f"lr must be in (0, 1), got {lr}")
+    if batch_size & (batch_size - 1) != 0:
+        raise ValueError(f"batch_size must be power of 2, got {batch_size}")
+
+    print(f"Training with lr={lr}, batch={batch_size}, precision={precision.value}")
+
+if __name__ == "__main__":
+    train()
+```
+
+## Testing Pattern
+
+```python
+from params_proto import proto
+
+@proto.cli(prog="train")  # Fixed name for reproducible help text
+def train(lr: float = 0.001):
+    """Train a model."""
+    return {"lr": lr}
+
+# Test programmatically (bypasses CLI parsing)
+def test_train():
+    result = train(lr=0.01)
+    assert result["lr"] == 0.01
+
+# Test help text
+def test_help():
+    assert "--lr FLOAT" in train.__help_str__
+    assert "(default: 0.001)" in train.__help_str__
+```

--- a/.claude/skills/params-proto/features/environment-vars.md
+++ b/.claude/skills/params-proto/features/environment-vars.md
@@ -1,0 +1,157 @@
+# Environment Variables
+
+params-proto supports reading configuration from environment variables.
+
+## Basic Usage
+
+```python
+from params_proto import proto, EnvVar
+
+@proto.cli
+def train(
+    lr: float = EnvVar @ "LEARNING_RATE" | 0.001,  # From env or default
+    api_key: str = EnvVar @ "API_KEY",  # Required env var
+    host: str = EnvVar @ "HOST" | "localhost",
+): ...
+```
+
+## Syntax
+
+```python
+EnvVar @ "ENV_VAR_NAME" | default_value
+```
+
+- `@` specifies the environment variable name
+- `|` provides a fallback default value
+- Without `|`, the env var is required
+
+## Type Conversion
+
+Values are automatically converted based on type hint:
+
+```python
+@proto.cli
+def train(
+    lr: float = EnvVar @ "LR" | 0.001,  # String → float
+    batch_size: int = EnvVar @ "BATCH" | 32,  # String → int
+    debug: bool = EnvVar @ "DEBUG" | False,  # String → bool
+): ...
+```
+
+Boolean conversion:
+- True: `"true"`, `"1"`, `"yes"`, `"on"` (case-insensitive)
+- False: `"false"`, `"0"`, `"no"`, `"off"`
+
+## Required Environment Variables
+
+```python
+@proto.cli
+def deploy(
+    api_key: str = EnvVar @ "API_KEY",  # No default = required
+): ...
+```
+
+Missing required env var raises error at import time.
+
+## With @proto.prefix
+
+```python
+@proto.prefix
+class Config:
+    host: str = EnvVar @ "HOST" | "localhost"
+    port: int = EnvVar @ "PORT" | 8080
+    debug: bool = EnvVar @ "DEBUG" | False
+```
+
+## Template Expansion
+
+Multiple variables in one value:
+
+```python
+@proto.cli
+def connect(
+    url: str = EnvVar @ "PROTOCOL://$HOST:$PORT/api",
+): ...
+```
+
+```bash
+PROTOCOL=https HOST=example.com PORT=443 python connect.py
+# url = "https://example.com:443/api"
+```
+
+Supported syntax:
+- `$VAR`
+- `${VAR}`
+
+## Priority Order
+
+1. CLI arguments (highest)
+2. Direct assignment
+3. Environment variables
+4. Default values (lowest)
+
+```python
+@proto.cli
+def train(
+    lr: float = EnvVar @ "LR" | 0.001,
+): ...
+```
+
+```bash
+# Uses env var
+LR=0.01 python train.py
+# lr = 0.01
+
+# CLI overrides env var
+LR=0.01 python train.py --lr 0.1
+# lr = 0.1
+```
+
+## In Help Text
+
+Environment variables appear in help:
+
+```
+--lr FLOAT    Learning rate (default: $LEARNING_RATE or 0.001)
+```
+
+## Common Patterns
+
+### Database Configuration
+
+```python
+@proto.prefix
+class Database:
+    host: str = EnvVar @ "DB_HOST" | "localhost"
+    port: int = EnvVar @ "DB_PORT" | 5432
+    user: str = EnvVar @ "DB_USER" | "postgres"
+    password: str = EnvVar @ "DB_PASSWORD"  # Required, no default
+    name: str = EnvVar @ "DB_NAME" | "myapp"
+```
+
+### API Keys
+
+```python
+@proto.prefix
+class API:
+    openai_key: str = EnvVar @ "OPENAI_API_KEY"
+    anthropic_key: str = EnvVar @ "ANTHROPIC_API_KEY"
+```
+
+### Feature Flags
+
+```python
+@proto.prefix
+class Features:
+    enable_cache: bool = EnvVar @ "ENABLE_CACHE" | True
+    debug_mode: bool = EnvVar @ "DEBUG" | False
+    log_level: str = EnvVar @ "LOG_LEVEL" | "INFO"
+```
+
+## Best Practices
+
+1. **Use uppercase for env vars** - `LEARNING_RATE` not `learning_rate`
+2. **Provide defaults for optional** - `EnvVar @ "VAR" | default`
+3. **Document required vars** - In comments or README
+4. **Use prefixes for grouping** - `DB_HOST`, `DB_PORT`, `API_KEY`
+5. **Don't commit secrets** - Use `.env` files, not code defaults

--- a/.claude/skills/params-proto/features/help-generation.md
+++ b/.claude/skills/params-proto/features/help-generation.md
@@ -1,0 +1,192 @@
+# Help Text Generation
+
+params-proto automatically generates CLI help text from code.
+
+## Sources of Help Text
+
+### 1. Inline Comments
+
+```python
+@proto.cli
+def train(
+    lr: float = 0.001,  # Learning rate for optimizer
+    batch_size: int = 32,  # Training batch size
+):
+    pass
+```
+
+### 2. Docstring Description
+
+```python
+@proto.cli
+def train(lr: float = 0.001):
+    """Train a neural network on CIFAR-10.
+
+    This trains a ResNet model using the specified hyperparameters.
+    """
+```
+
+### 3. Docstring Args Section
+
+```python
+@proto.cli
+def train(lr: float = 0.001):
+    """Train a model.
+
+    Args:
+        lr: Learning rate controlling gradient step size
+    """
+```
+
+### 4. Combined (Multi-line Help)
+
+```python
+@proto.cli
+def train(
+    lr: float = 0.001,  # Learning rate
+):
+    """Train a model.
+
+    Args:
+        lr: Controls optimization step size
+    """
+```
+
+Output:
+```
+--lr FLOAT    Learning rate
+              Controls optimization step size (default: 0.001)
+```
+
+## Help Text Elements
+
+### Usage Line
+
+```
+usage: script.py [-h] [--lr FLOAT] [--batch-size INT]
+```
+
+- Shows program name
+- Lists all arguments with types
+- Boolean flags show `--flag` or `--no-flag` based on default
+
+### Description
+
+From the function/class docstring (first paragraph).
+
+### Options Section
+
+```
+options:
+  -h, --help           show this help message and exit
+  --lr FLOAT           Learning rate (default: 0.001)
+  --batch-size INT     Training batch size (default: 32)
+```
+
+### Prefix Sections
+
+For `@proto.prefix` classes:
+
+```
+Model options:
+  Model configuration.
+
+  --model.name STR     Architecture name (default: resnet50)
+  --model.layers INT   Number of layers (default: 50)
+```
+
+## Type Display
+
+| Type | Display |
+|------|---------|
+| `int` | `INT` |
+| `float` | `FLOAT` |
+| `str` | `STR` |
+| `bool` | `BOOL` |
+| `Enum` | `{MEMBER1,MEMBER2}` |
+| Other | `VALUE` |
+
+## Default Values
+
+```
+--lr FLOAT    Learning rate (default: 0.001)
+--seed INT    Random seed (required)
+```
+
+- Optional params show `(default: value)`
+- Required params show `(required)`
+
+## Boolean Flag Display
+
+```python
+@proto.cli
+def train(
+    verbose: bool = False,  # Enable verbose logging
+    cuda: bool = True,  # Use CUDA acceleration
+): ...
+```
+
+Output:
+```
+--verbose BOOL       Enable verbose logging (default: False)
+--no-cuda BOOL       Use CUDA acceleration (default: True)
+```
+
+- `default=False` → shows `--flag`
+- `default=True` → shows `--no-flag`
+
+## ANSI Colors (Terminal)
+
+When running in a terminal, help text is colorized:
+
+- **Type names** (INT, FLOAT, etc.) → Bold bright blue
+- **(required)** → Bold red
+- **(default: value)** → Cyan with bold value
+
+## Customizing Program Name
+
+```python
+@proto.cli(prog="my-trainer")
+def train(): ...
+```
+
+Shows `usage: my-trainer` instead of filename.
+
+## Auto-generated Descriptions
+
+If no comment or docstring arg:
+
+```python
+@proto.cli
+def train(
+    learning_rate: float = 0.001,  # No comment
+): ...
+```
+
+Generates: `Learning rate (default: 0.001)`
+
+- Underscores → spaces
+- First letter capitalized
+
+## Long Parameter Names
+
+```python
+@proto.cli
+def train(
+    this_is_a_very_long_parameter_name: int = 100,  # Description
+): ...
+```
+
+Output wraps:
+```
+--this-is-a-very-long-parameter-name INT
+                     Description (default: 100)
+```
+
+## Best Practices
+
+1. **Write clear inline comments** - Primary source of help text
+2. **Keep descriptions concise** - One line ideally
+3. **Document constraints** - "Learning rate in (0, 1)"
+4. **Use docstrings for overview** - Explain what the command does
+5. **Test with --help** - Verify output is clear

--- a/.claude/skills/params-proto/features/sweeps.md
+++ b/.claude/skills/params-proto/features/sweeps.md
@@ -1,0 +1,200 @@
+# Hyperparameter Sweeps
+
+params-proto provides `Sweep` for systematic hyperparameter exploration.
+
+## Basic Usage
+
+```python
+from params_proto import proto, Sweep
+
+@proto.cli
+def train(lr: float = 0.001, batch_size: int = 32):
+    print(f"Training with lr={lr}, batch={batch_size}")
+
+# Create sweep
+sweep = Sweep(train)
+```
+
+## Grid Search (Product)
+
+```python
+sweep = Sweep(train).product(
+    lr=[0.001, 0.01, 0.1],
+    batch_size=[32, 64, 128],
+)
+
+# 3 × 3 = 9 configurations
+for config in sweep:
+    train(**config)
+```
+
+## Zip (Paired Values)
+
+```python
+sweep = Sweep(train).zip(
+    lr=[0.001, 0.01, 0.1],
+    batch_size=[32, 64, 128],
+)
+
+# 3 configurations (paired)
+# (0.001, 32), (0.01, 64), (0.1, 128)
+for config in sweep:
+    train(**config)
+```
+
+## Combined Sweeps
+
+```python
+sweep = Sweep(train).product(
+    lr=[0.001, 0.01],
+).zip(
+    batch_size=[32, 64],
+    epochs=[100, 200],
+)
+
+# 2 × 2 = 4 configurations
+# lr varies independently, batch_size and epochs are paired
+```
+
+## Chain (Sequential)
+
+```python
+sweep = Sweep(train).chain(
+    {"lr": 0.001, "batch_size": 32},
+    {"lr": 0.01, "batch_size": 64},
+    {"lr": 0.1, "batch_size": 128},
+)
+```
+
+## Set (Fixed Values)
+
+```python
+sweep = Sweep(train).set(
+    epochs=100,  # Fixed for all configs
+).product(
+    lr=[0.001, 0.01, 0.1],
+)
+```
+
+## With @proto.prefix
+
+```python
+@proto.prefix
+class Training:
+    lr: float = 0.001
+    batch_size: int = 32
+
+@proto.cli
+def main(seed: int = 42):
+    print(f"lr={Training.lr}, batch={Training.batch_size}")
+
+# Sweep over prefix class
+sweep = Sweep(Training).product(
+    lr=[0.001, 0.01],
+    batch_size=[32, 64],
+)
+
+for config in sweep:
+    with proto.bind(Training, **config):
+        main()
+```
+
+## Iteration
+
+```python
+# As iterator
+for config in sweep:
+    train(**config)
+
+# As list
+configs = list(sweep)
+print(f"Total: {len(configs)} configurations")
+
+# With index
+for i, config in enumerate(sweep):
+    print(f"Config {i}: {config}")
+```
+
+## Saving and Loading
+
+```python
+# Save to file
+sweep.save("sweep.yaml")
+
+# Load from file
+sweep = Sweep.load("sweep.yaml")
+```
+
+## DataFrame Export
+
+```python
+import pandas as pd
+
+df = sweep.to_dataframe()
+print(df)
+```
+
+## Operators
+
+```python
+# Multiplication = product
+sweep = Sweep(train) * {"lr": [0.001, 0.01]} * {"batch_size": [32, 64]}
+
+# Power = repeat
+sweep = Sweep(train) ** 3  # 3 repetitions
+
+# Modulo with dict = set
+sweep = Sweep(train) % {"epochs": 100}
+```
+
+## Common Patterns
+
+### Learning Rate Search
+
+```python
+sweep = Sweep(train).product(
+    lr=[1e-5, 1e-4, 1e-3, 1e-2, 1e-1],
+)
+```
+
+### Architecture Search
+
+```python
+sweep = Sweep(train).product(
+    model=["resnet18", "resnet50", "vit"],
+    dropout=[0.1, 0.3, 0.5],
+)
+```
+
+### Random Seeds
+
+```python
+sweep = Sweep(train).product(
+    seed=[42, 123, 456, 789, 1337],
+).set(
+    lr=0.001,
+    batch_size=32,
+)
+```
+
+### Ablation Study
+
+```python
+# Baseline
+baseline = {"lr": 0.001, "batch_size": 32, "augment": False}
+
+sweep = Sweep(train).chain(
+    baseline,
+    {**baseline, "augment": True},
+    {**baseline, "lr": 0.01},
+    {**baseline, "batch_size": 64},
+)
+```
+
+## Best Practices
+
+1. **Start small** - Test with few values first
+2. **Use meaningful ranges** - Based on domain knowledge
+3. **Track results** - Log metrics for each config
+4. **Parallelize** - Run configs in parallel when possible
+5. **Save sweeps** - For reproducibility

--- a/.claude/skills/params-proto/index.md
+++ b/.claude/skills/params-proto/index.md
@@ -1,0 +1,72 @@
+# params-proto Skill
+
+A Claude skill for working with params-proto v3 - a declarative hyperparameter management library for ML.
+
+## When to Use This Skill
+
+Use this skill when helping users:
+- Create CLI applications with type-hinted parameters
+- Configure ML training scripts with hyperparameters
+- Set up multi-namespace configurations
+- Work with environment variables in configs
+- Create hyperparameter sweeps
+
+## Quick Reference
+
+### Three Decorators
+
+| Decorator | Purpose | Use Case |
+|-----------|---------|----------|
+| `@proto.cli` | CLI entry point | Script entry points, parses sys.argv |
+| `@proto.prefix` | Singleton config | Global namespaced configs (`Model.lr`) |
+| `@proto` | Multi-instance | Reusable config classes |
+
+### Basic Pattern
+
+```python
+from params_proto import proto
+
+@proto.cli
+def train(
+    lr: float = 0.001,  # Learning rate (inline comment = help text)
+    batch_size: int = 32,  # Batch size
+    epochs: int = 100,  # Number of epochs
+):
+    """Train a model."""  # Docstring = CLI description
+    print(f"Training with lr={lr}")
+
+if __name__ == "__main__":
+    train()
+```
+
+### Multi-Namespace Pattern
+
+```python
+@proto.prefix
+class Model:
+    name: str = "resnet50"  # Architecture
+    dropout: float = 0.5  # Dropout rate
+
+@proto.prefix
+class Training:
+    lr: float = 0.001  # Learning rate
+    epochs: int = 100  # Epochs
+
+@proto.cli
+def main(seed: int = 42):
+    """Train with namespaced config."""
+    print(f"Model: {Model.name}, LR: {Training.lr}")
+```
+
+CLI: `python train.py --model.name vit --training.lr 0.01`
+
+## Skill Contents
+
+- [quick-reference.md](quick-reference.md) - Cheat sheet for common patterns
+- [api/proto-cli.md](api/proto-cli.md) - @proto.cli decorator details
+- [api/proto-prefix.md](api/proto-prefix.md) - @proto.prefix for singletons
+- [api/types.md](api/types.md) - Supported type annotations
+- [features/help-generation.md](features/help-generation.md) - Auto help text
+- [features/environment-vars.md](features/environment-vars.md) - EnvVar support
+- [features/sweeps.md](features/sweeps.md) - Hyperparameter sweeps
+- [examples/patterns.md](examples/patterns.md) - Common patterns

--- a/.claude/skills/params-proto/quick-reference.md
+++ b/.claude/skills/params-proto/quick-reference.md
@@ -1,0 +1,208 @@
+# params-proto Quick Reference
+
+## Installation
+
+```bash
+pip install params-proto==3.0.0-rc6
+```
+
+## Decorators
+
+```python
+from params_proto import proto
+
+# CLI entry point - parses sys.argv
+@proto.cli
+def main(lr: float = 0.001): ...
+
+# Singleton config - access as ClassName.attr
+@proto.prefix
+class Config:
+    lr: float = 0.001
+
+# Multi-instance config
+@proto
+class Params:
+    lr: float = 0.001
+```
+
+## Type Annotations
+
+| Type | CLI Display | Example |
+|------|-------------|---------|
+| `int` | `INT` | `count: int = 10` |
+| `float` | `FLOAT` | `lr: float = 0.001` |
+| `str` | `STR` | `name: str = "default"` |
+| `bool` | `BOOL` | `debug: bool = False` |
+| `Enum` | `{A,B,C}` | `opt: Optimizer = Optimizer.ADAM` |
+| `Literal` | `VALUE` | `mode: Literal["a", "b"] = "a"` |
+| `List[T]` | `VALUE` | `ids: List[int] = [1, 2]` |
+| `Optional[T]` | `VALUE` | `path: str \| None = None` |
+| `Path` | `VALUE` | `dir: Path = Path(".")` |
+
+## Boolean Flags
+
+```python
+@proto.cli
+def train(
+    verbose: bool = False,  # --verbose BOOL sets True
+    cuda: bool = True,      # --no-cuda BOOL sets False
+): ...
+```
+
+- Default `False` → help shows `--flag`
+- Default `True` → help shows `--no-flag`
+
+## CLI Argument Syntax
+
+```bash
+# Named arguments (underscore → hyphen)
+python train.py --learning-rate 0.01 --batch-size 64
+
+# Positional for required params
+python train.py 42  # First required param
+
+# Boolean flags
+python train.py --verbose      # Set to True
+python train.py --no-cuda      # Set to False
+
+# Prefix syntax
+python train.py --model.name resnet --training.lr 0.01
+```
+
+## Environment Variables
+
+```python
+from params_proto import proto, EnvVar
+
+@proto.cli
+def train(
+    lr: float = EnvVar @ "LEARNING_RATE" | 0.001,  # Env var with default
+    api_key: str = EnvVar @ "API_KEY",  # Required env var
+    host: str = EnvVar @ "HOST" | "localhost",
+): ...
+```
+
+```bash
+LEARNING_RATE=0.01 python train.py
+```
+
+## Override Patterns
+
+```python
+# 1. CLI
+python train.py --lr 0.01
+
+# 2. Direct assignment (for @proto.prefix classes)
+Training.lr = 0.01
+
+# 3. Context manager
+with proto.bind(Training, lr=0.01):
+    train()
+
+# 4. Instance creation
+config = Params(lr=0.01)
+```
+
+## Help Text Generation
+
+```python
+@proto.cli
+def train(
+    lr: float = 0.001,  # This comment → help text
+):
+    """This docstring → CLI description."""
+```
+
+Output:
+```
+usage: train.py [-h] [--lr FLOAT]
+
+This docstring → CLI description.
+
+options:
+  --lr FLOAT    This comment → help text (default: 0.001)
+```
+
+## Multi-Namespace Config
+
+```python
+@proto.prefix
+class Model:
+    """Model configuration."""
+    name: str = "resnet50"
+    layers: int = 50
+
+@proto.prefix
+class Training:
+    """Training hyperparameters."""
+    lr: float = 0.001
+    epochs: int = 100
+
+@proto.cli
+def main(seed: int = 42):
+    print(f"{Model.name} with lr={Training.lr}")
+
+if __name__ == "__main__":
+    main()
+```
+
+```bash
+python train.py --model.name vit --training.lr 0.0001
+```
+
+## Hyperparameter Sweeps
+
+```python
+from params_proto import proto, Sweep
+
+@proto.cli
+def train(lr: float = 0.001, batch_size: int = 32): ...
+
+# Grid sweep
+sweep = Sweep(train).product(
+    lr=[0.001, 0.01, 0.1],
+    batch_size=[32, 64, 128],
+)
+
+for config in sweep:
+    train(**config)
+```
+
+## Common Patterns
+
+### Required Parameters
+
+```python
+@proto.cli
+def train(
+    seed: int,  # No default = required, shows (required) in help
+    lr: float = 0.001,
+): ...
+```
+
+### Union Types (Subcommand-like)
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class Adam:
+    lr: float = 0.001
+    beta1: float = 0.9
+
+@dataclass
+class SGD:
+    lr: float = 0.01
+    momentum: float = 0.9
+
+@proto.cli
+def train(optimizer: Adam | SGD):
+    """Train with selected optimizer."""
+    print(f"Using {type(optimizer).__name__}")
+```
+
+```bash
+python train.py adam --lr 0.001
+python train.py sgd --momentum 0.95
+```

--- a/docs/key_concepts/claude_skill.md
+++ b/docs/key_concepts/claude_skill.md
@@ -1,0 +1,59 @@
+# Claude Skill
+
+params-proto includes a Claude skill that helps AI assistants work with the library effectively.
+
+## What is a Claude Skill?
+
+A Claude skill is a collection of documentation files that Claude Code and other Claude-based tools can use to provide better assistance when working with a library or codebase.
+
+## Using the Skill
+
+### In Claude Code
+
+If you're using Claude Code in a project that depends on params-proto, point to the skill directory:
+
+```bash
+# In your project's .claude/settings.json or CLAUDE.md
+# Reference the skill from the installed package or cloned repo
+```
+
+### Importing the Skill
+
+You can reference the skill files from the params-proto repository:
+
+```
+.claude/skills/params-proto/
+├── index.md              # Overview and navigation
+├── quick-reference.md    # Cheat sheet
+├── api/
+│   ├── proto-cli.md      # @proto.cli decorator
+│   ├── proto-prefix.md   # @proto.prefix decorator
+│   └── types.md          # Type annotations
+├── features/
+│   ├── help-generation.md    # Auto help text
+│   ├── environment-vars.md   # EnvVar support
+│   └── sweeps.md             # Hyperparameter sweeps
+└── examples/
+    └── patterns.md       # Common patterns
+```
+
+### Via Raw GitHub URL
+
+You can reference the skill files directly from GitHub:
+
+```
+https://raw.githubusercontent.com/geyang/params-proto/main/.claude/skills/params-proto/index.md
+```
+
+## Skill Contents
+
+The skill provides:
+
+1. **Quick Reference** - Cheat sheet for common patterns and syntax
+2. **API Documentation** - Detailed docs for each decorator
+3. **Feature Guides** - Help generation, environment variables, sweeps
+4. **Examples** - Common patterns for ML training, multi-namespace configs
+
+## Contributing to the Skill
+
+The skill files are located in `.claude/skills/params-proto/`. PRs welcome to improve the documentation!


### PR DESCRIPTION
## Summary

- Add hierarchical Claude skill documentation in `.claude/skills/params-proto/`
- Add docs page explaining how to use the skill

## Skill Structure

```
.claude/skills/params-proto/
├── index.md              # Overview and navigation
├── quick-reference.md    # Cheat sheet
├── api/
│   ├── proto-cli.md      # @proto.cli decorator
│   ├── proto-prefix.md   # @proto.prefix decorator
│   └── types.md          # Type annotations
├── features/
│   ├── help-generation.md
│   ├── environment-vars.md
│   └── sweeps.md
└── examples/
    └── patterns.md
```

## Test plan

- [x] Verify skill files are well-formatted markdown
- [x] Check all code examples are syntactically correct
- [ ] Test skill with Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)