### PR TITLE
Fix classmethod/staticmethod in @proto decorated classes

### DIFF
--- a/docs/key_concepts/configuration_basics.md
+++ b/docs/key_concepts/configuration_basics.md
@@ -256,6 +256,54 @@ if __name__ == "__main__":
 
 Or use `@proto.prefix` for global configuration (see [Advanced Patterns](advanced_patterns.md#prefixed-configurations)).
 
+### Methods in Configuration Classes
+
+`@proto` classes can include methods just like regular classes. Methods (`classmethod`, `staticmethod`, and instance methods) work as expected:
+
+```python
+@proto
+class Config:
+    lr: float = 0.01
+    batch_size: int = 32
+
+    @classmethod
+    def from_preset(cls, preset: str = "default"):
+        """Create config from a preset."""
+        if preset == "large":
+            cls.lr = 0.001
+            cls.batch_size = 128
+        return cls()
+
+    @staticmethod
+    def validate_lr(lr: float) -> bool:
+        """Validate learning rate."""
+        return 0 < lr < 1.0
+
+    def summary(self):
+        """Return config summary."""
+        return f"lr={self.lr}, batch_size={self.batch_size}"
+```
+
+**Usage:**
+```python
+# Classmethod receives the correct cls
+config = Config.from_preset("large")
+print(config.lr)  # 0.001
+
+# Staticmethod works as expected
+assert Config.validate_lr(0.01) is True
+
+# Instance methods work normally
+config = Config()
+print(config.summary())  # lr=0.01, batch_size=32
+```
+
+**Key points:**
+- Methods are **not** included in configuration parameters (only type-annotated class attributes are)
+- `@classmethod` receives the correct wrapped class, so modifications to `cls` attributes reflect in the config
+- `@staticmethod` works identically to regular classes
+- Instance methods have access to instance attributes via `self`
+
 ## Choosing Between Functions and Classes
 
 ### Use Functions When:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "params-proto"
-version = "3.0.0-rc10"
+version = "3.0.0-rc11"
 description = "Modern Hyper Parameter Management for Machine Learning"
 authors = [
     { name = "Ge Yang" }

--- a/src/params_proto/proto.py
+++ b/src/params_proto/proto.py
@@ -764,7 +764,12 @@ def proto(
       for key in dir(obj):
         if not key.startswith("__") or key in ("__annotations__", "__module__", "__qualname__", "__doc__"):
           try:
-            namespace[key] = getattr(obj, key)
+            # Use __dict__ to preserve classmethod/staticmethod descriptors
+            # getattr() would return bound methods instead of descriptors
+            if key in obj.__dict__:
+              namespace[key] = obj.__dict__[key]
+            else:
+              namespace[key] = getattr(obj, key)
           except AttributeError:
             pass
 

--- a/tests/test_v3/test_class_level_methods.py
+++ b/tests/test_v3/test_class_level_methods.py
@@ -1,0 +1,112 @@
+"""Tests for @proto decorator on classes that contain classmethod/staticmethod."""
+
+from params_proto import proto
+
+
+class TestClassLevelProtoWithMethods:
+  """Test @proto decorator on class that contains classmethod/staticmethod."""
+
+  def test_proto_class_with_classmethod(self):
+    """Test @proto on class with @classmethod inside."""
+
+    @proto
+    class Config:
+      lr: float = 0.01
+      batch_size: int = 32
+
+      @classmethod
+      def from_preset(cls, preset: str = "default"):
+        """Create config from preset."""
+        if preset == "large":
+          cls.lr = 0.001
+          cls.batch_size = 128
+        return cls()
+
+    # Class attributes should work
+    assert Config.lr == 0.01
+    assert Config.batch_size == 32
+
+    # Classmethod should still be callable
+    config = Config.from_preset("large")
+    assert config.lr == 0.001
+    assert config.batch_size == 128
+
+  def test_proto_class_with_staticmethod(self):
+    """Test @proto on class with @staticmethod inside."""
+
+    @proto
+    class Config:
+      lr: float = 0.01
+      batch_size: int = 32
+
+      @staticmethod
+      def validate_lr(lr: float) -> bool:
+        """Validate learning rate."""
+        return 0 < lr < 1.0
+
+    # Class attributes should work
+    assert Config.lr == 0.01
+    assert Config.batch_size == 32
+
+    # Staticmethod should still work
+    assert Config.validate_lr(0.01) is True
+    assert Config.validate_lr(1.5) is False
+
+  def test_proto_class_with_instance_method(self):
+    """Test @proto on class with regular instance method inside."""
+
+    @proto
+    class Config:
+      lr: float = 0.01
+      batch_size: int = 32
+
+      def summary(self):
+        """Return config summary."""
+        return f"lr={self.lr}, batch_size={self.batch_size}"
+
+    # Class attributes should work
+    assert Config.lr == 0.01
+
+    # Instance method should work
+    config = Config()
+    assert config.summary() == "lr=0.01, batch_size=32"
+
+  def test_proto_class_classmethod_receives_correct_cls(self):
+    """Test that @classmethod in @proto class receives the correct cls."""
+
+    @proto
+    class Config:
+      name: str = "base"
+
+      @classmethod
+      def get_name(cls):
+        return cls.name
+
+    assert Config.get_name() == "base"
+    Config.name = "modified"
+    assert Config.get_name() == "modified"
+
+  def test_proto_class_methods_not_in_annotations(self):
+    """Test that methods are not included in __proto_annotations__."""
+
+    @proto
+    class Config:
+      lr: float = 0.01
+
+      @classmethod
+      def factory(cls):
+        return cls()
+
+      @staticmethod
+      def helper():
+        return True
+
+      def instance_method(self):
+        return self.lr
+
+    # Only lr should be in annotations, not methods
+    annotations = Config.__proto_annotations__
+    assert "lr" in annotations
+    assert "factory" not in annotations
+    assert "helper" not in annotations
+    assert "instance_method" not in annotations


### PR DESCRIPTION
## Summary
- Fix bug where `@classmethod` and `@staticmethod` in `@proto` decorated classes received the original unwrapped class instead of the wrapped ptype class
- Preserve method descriptors by using `obj.__dict__[key]` instead of `getattr(obj, key)` when copying class attributes
- Add comprehensive test coverage in `test_class_level_methods.py`
- Add documentation section "Methods in Configuration Classes" to configuration_basics.md
- Bump version to 3.0.0-rc11

## Test plan
- [x] Run `pytest tests/test_v3/test_class_level_methods.py` - all 5 tests pass
- [x] Run full test suite `pytest tests/test_v3/` - all 235 tests pass
- [ ] Review documentation changes

cc @yanbing-han

🤖 Generated with [Claude Code](https://claude.com/claude-code)