### PR TITLE
Support Python 3.10 by using Union[] syntax

### DIFF
--- a/examples/union_subcommands.py
+++ b/examples/union_subcommands.py
@@ -11,56 +11,57 @@ Usage:
 """
 
 from dataclasses import dataclass
+from typing import Union
 
 from params_proto import proto
 
 
 @dataclass
 class PerspectiveCamera:
-    """Perspective camera with field of view."""
+  """Perspective camera with field of view."""
 
-    fov: float = 60.0  # Field of view in degrees
-    aspect: float = 1.33  # Aspect ratio (width/height)
-    near: float = 0.1  # Near clipping plane
-    far: float = 100.0  # Far clipping plane
+  fov: float = 60.0  # Field of view in degrees
+  aspect: float = 1.33  # Aspect ratio (width/height)
+  near: float = 0.1  # Near clipping plane
+  far: float = 100.0  # Far clipping plane
 
 
 @dataclass
 class OrthographicCamera:
-    """Orthographic camera with uniform scale."""
+  """Orthographic camera with uniform scale."""
 
-    scale: float = 1.0  # Orthographic scale
-    near: float = 0.1  # Near clipping plane
-    far: float = 100.0  # Far clipping plane
+  scale: float = 1.0  # Orthographic scale
+  near: float = 0.1  # Near clipping plane
+  far: float = 100.0  # Far clipping plane
 
 
 @proto.cli
 def view(
-    camera: PerspectiveCamera | OrthographicCamera,  # Required subcommand
-    output: str = "render.png",  # Output file
-    verbose: bool = False,  # Verbose logging
+  camera: Union[PerspectiveCamera, OrthographicCamera],  # Required subcommand
+  output: str = "render.png",  # Output file
+  verbose: bool = False,  # Verbose logging
 ):
-    """
-    Render a 3D scene with the specified camera.
+  """
+  Render a 3D scene with the specified camera.
 
-    Args:
-        camera: Camera configuration (perspective or orthographic)
-        output: Output file path
-        verbose: Enable verbose logging
-    """
-    if verbose:
-        print(f"Rendering to: {output}")
+  Args:
+      camera: Camera configuration (perspective or orthographic)
+      output: Output file path
+      verbose: Enable verbose logging
+  """
+  if verbose:
+    print(f"Rendering to: {output}")
 
-    if isinstance(camera, PerspectiveCamera):
-        print(f"Perspective Camera:")
-        print(f"  FOV: {camera.fov}°")
-        print(f"  Aspect Ratio: {camera.aspect}")
-        print(f"  Clipping: {camera.near} to {camera.far}")
-    elif isinstance(camera, OrthographicCamera):
-        print(f"Orthographic Camera:")
-        print(f"  Scale: {camera.scale}")
-        print(f"  Clipping: {camera.near} to {camera.far}")
+  if isinstance(camera, PerspectiveCamera):
+    print("Perspective Camera:")
+    print(f"  FOV: {camera.fov}°")
+    print(f"  Aspect Ratio: {camera.aspect}")
+    print(f"  Clipping: {camera.near} to {camera.far}")
+  elif isinstance(camera, OrthographicCamera):
+    print("Orthographic Camera:")
+    print(f"  Scale: {camera.scale}")
+    print(f"  Clipping: {camera.near} to {camera.far}")
 
 
 if __name__ == "__main__":
-    view()
+  view()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "params-proto"
-version = "3.0.0-rc15"
+version = "3.0.0-rc16"
 description = "Modern Hyper Parameter Management for Machine Learning"
 authors = [
     { name = "Ge Yang" }

--- a/src/params_proto/cli/cli_parse.py
+++ b/src/params_proto/cli/cli_parse.py
@@ -6,7 +6,7 @@ Simple custom parser - no argparse dependency.
 """
 
 import sys
-from typing import Any, Dict, get_args, get_origin
+from typing import Any, Dict, Union, get_args, get_origin
 
 from params_proto.type_utils import _convert_type
 
@@ -55,7 +55,7 @@ def _normalize_class_name(class_name: str) -> str:
   return class_name.replace("-", "").replace("_", "").lower()
 
 
-def _match_class_by_name(name: str, classes: list) -> type | None:
+def _match_class_by_name(name: str, classes: list) -> Union[type, None]:
   """Match a string to one of the Union classes.
 
   Supports:
@@ -79,7 +79,7 @@ def _match_class_by_name(name: str, classes: list) -> type | None:
 
     # Try abbreviated match: 'perspective' should match 'PerspectiveCamera'
     # Extract first word from PascalCase class name
-    words = re.findall(r'[A-Z][a-z]*', cls.__name__)
+    words = re.findall(r"[A-Z][a-z]*", cls.__name__)
     if words and words[0].lower() == name.lower():
       return cls
 
@@ -121,7 +121,16 @@ def parse_cli_args(wrapper) -> Dict[str, Any]:
 
     # Check if this is a single class type (dataclass, etc.)
     # Treat as a "union" with one option to enable same syntax
-    if isinstance(annotation, type) and annotation not in {int, str, float, bool, list, dict, tuple, set}:
+    if isinstance(annotation, type) and annotation not in {
+      int,
+      str,
+      float,
+      bool,
+      list,
+      dict,
+      tuple,
+      set,
+    }:
       union_params[kebab_name] = (param_name, [annotation])
       if param_info.get("required", False):
         required_params.append(param_name)
@@ -340,6 +349,7 @@ def parse_cli_args(wrapper) -> Dict[str, Any]:
 
     # If selected_class is a proto.prefix singleton, merge its overrides
     from params_proto.proto import _SINGLETONS, ptype
+
     for singleton_key, singleton in _SINGLETONS.items():
       if singleton is selected_class:
         # This is a proto.prefix class - merge overrides into attrs


### PR DESCRIPTION
## Summary

This PR adds support for Python 3.10 (and maintains compatibility with Python 3.8+):

- Replace `X | Y` union type syntax with `Union[X, Y]` in `cli_parse.py`
- Update `union_subcommands.py` example to use `Union[]` syntax
- Bump version to `3.0.0-rc16`

The `|` syntax for type unions in annotations only works at runtime starting Python 3.10, so we use the `Union[]` syntax from the `typing` module to maintain backward compatibility.

## Test plan

- [x] Verified `python examples/union_subcommands.py perspective-camera` works
- [x] Ran test suite (317 passed, 2 environment-specific help text tests skipped)

cc @marvinluo1 @tomtao57

🤖 Generated with [Claude Code](https://claude.com/claude-code)