### PR TITLE
Release v3.0.0-rc18

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,22 +1,42 @@
 # Release Process
 
-## Full Release (with PyPI publish)
+## Full Release (with PR and PyPI publish)
 
-### 1. Bump Version
+### 1. Prepare Changes
 
-Update `pyproject.toml`:
+Update `pyproject.toml` version:
 ```toml
 version = "3.0.0-rcX"
 ```
 
-### 2. Commit and Push
+Update `docs/release_notes.md` with changes.
+
+Update `skill/quick-reference.md` version if needed.
+
+### 2. Create PR
 
 ```bash
-git add -A && git commit -m "Bump version to 3.0.0-rcX"
-git push origin main
+# Create feature branch
+git checkout -b release/v3.0.0-rcX
+
+# Commit all changes
+git add -A && git commit -m "Release v3.0.0-rcX: brief description"
+
+# Push and create PR
+git push -u origin release/v3.0.0-rcX
+gh pr create --title "Release v3.0.0-rcX" --body "## Changes
+- Feature/fix 1
+- Feature/fix 2"
 ```
 
-### 3. Create Tags
+### 3. Merge PR
+
+```bash
+gh pr merge --squash --delete-branch
+git checkout main && git pull
+```
+
+### 4. Create Tags
 
 ```bash
 git tag -f v3.0.0-rcX HEAD
@@ -25,15 +45,15 @@ git push origin refs/tags/v3.0.0-rcX --force
 git push origin refs/tags/latest --force
 ```
 
-### 4. Create GitHub Release
+### 5. Create GitHub Release
 
 ```bash
 gh release create v3.0.0-rcX --title "v3.0.0-rcX" --latest --notes "## Changes
-- Feature 1
-- Feature 2"
+- Feature/fix 1
+- Feature/fix 2"
 ```
 
-### 5. Publish to PyPI
+### 6. Publish to PyPI
 
 ```bash
 rm -rf dist && uv build
@@ -45,7 +65,7 @@ uv publish --token "$(pass show pypi | head -1)"
 When updating docs without a new PyPI release:
 
 ```bash
-# Commit and push
+# Commit and push directly to main
 git add -A && git commit -m "Update docs: description"
 git push origin main
 
@@ -54,4 +74,20 @@ git tag -f latest HEAD
 git push origin refs/tags/latest --force
 ```
 
-Note: RTD uses the `latest` tag (not branch) to build documentation.
+## Quick Fixes (No PR needed)
+
+For small fixes that don't need review:
+
+```bash
+# Commit and push to main
+git add -A && git commit -m "Fix: description"
+git push origin main
+
+# If releasing: follow steps 4-6 above
+```
+
+## Notes
+
+- RTD uses the `latest` tag (not branch) to build documentation
+- Always update `docs/release_notes.md` for code changes
+- Update `skill/quick-reference.md` version number for new releases

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -2,6 +2,64 @@
 
 This page contains the release history and changelog for params-proto.
 
+## Version 3.0.0-rc18 (2025-12-26)
+
+### 🐛 Bug Fixes
+
+- **EnvVar Instantiation Fix**: Fixed `@proto.prefix` classes with EnvVar fields failing on instantiation
+  with `AttributeError: '_EnvVar' object has no attribute '__get__'`.
+
+  The bug occurred because `_EnvVar` is callable (has `__call__`), so it was incorrectly detected as a
+  method during instance creation. The fix uses precise method detection with `inspect.isfunction` and
+  `inspect.ismethod` instead of the overly broad `callable()` check.
+
+  ```python
+  from params_proto import proto, EnvVar
+
+  @proto.prefix
+  class Config:
+      host: str = EnvVar @ "HOST" | "localhost"
+
+  # Before fix: AttributeError: '_EnvVar' object has no attribute '__get__'
+  # After fix: works correctly
+  c = Config()
+  ```
+
+### 📚 Documentation
+
+- Added EnvVar + inheritance documentation and tests
+- Documented that inherited EnvVar fields are resolved and type-converted correctly
+
+---
+
+## Version 3.0.0-rc17 (2025-12-26)
+
+### ✨ Features
+
+- **Inherited Fields**: Support inherited fields in `@proto` classes. Parent class fields are now
+  properly included in `vars()`, CLI args, and work with EnvVar.
+
+  ```python
+  class BaseConfig:
+      host: str = EnvVar @ "HOST" | "localhost"
+      port: int = EnvVar @ "PORT" | 8080
+
+  @proto.prefix
+  class AppConfig(BaseConfig):
+      debug: bool = EnvVar @ "DEBUG" | False
+  ```
+
+---
+
+## Version 3.0.0-rc16 (2025-12-26)
+
+### 🐛 Bug Fixes
+
+- **Python 3.10 Support**: Use `Union[]` syntax instead of `|` operator for type hints to support
+  Python 3.10 (#17).
+
+---
+
 ## Version 3.0.0-rc15 (2025-12-19)
 
 ### 🐛 Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "params-proto"
-version = "3.0.0-rc17"
+version = "3.0.0-rc18"
 description = "Modern Hyper Parameter Management for Machine Learning"
 authors = [
     { name = "Ge Yang" }

--- a/skill/quick-reference.md
+++ b/skill/quick-reference.md
@@ -8,7 +8,7 @@ description: Cheat sheet for params-proto patterns and syntax
 ## Installation
 
 ```bash
-pip install params-proto==3.0.0-rc17
+pip install params-proto==3.0.0-rc18
 ```
 
 ## Decorators


### PR DESCRIPTION
## Summary

Fix `@proto.prefix` classes with EnvVar fields failing on instantiation.

## Bug Fix

**Before:** `AttributeError: '_EnvVar' object has no attribute '__get__'`

```python
@proto.prefix
class Config:
    host: str = EnvVar @ "HOST" | "localhost"

c = Config()  # ❌ AttributeError
```

**After:** Works correctly

```python
c = Config()  # ✅ Works
print(c.host)  # "localhost" or value from HOST env var
```

## Changes

- Fix method detection in `@proto.prefix` instantiation to use `inspect.isfunction`/`ismethod` instead of `callable()`
- Skip proto fields when copying methods to instances
- Add regression tests for EnvVar instantiation
- Add EnvVar + inheritance documentation
- Update CLAUDE.md with full release procedure

## Test Plan

- [x] `test_proto_prefix_envvar_instantiation` passes
- [x] `test_proto_prefix_envvar_instantiation_with_fallback` passes
- [x] All 251 v3 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)