### PR TITLE
Release v3.0.0-rc26

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -2,6 +2,23 @@
 
 This page contains the release history and changelog for params-proto.
 
+## Version 3.0.0-rc26 (2025-01-11)
+
+### ✨ Features
+
+- **Automatic Type Inference for Untyped Attributes**: Class attributes without explicit type annotations are now automatically inferred
+  - `name = "hello"` is treated as `name: str = "hello"`
+  - `count = 42` is treated as `count: int = 42`
+  - `data = None` is treated as `data: Any = None` (generic type)
+  - Untyped attributes now appear in `vars(self)` inside `__post_init__`
+  - Explicit type annotations are always preserved
+
+### 🐛 Bug Fixes
+
+- Untyped class attributes now correctly appear in `vars(self)` during `__post_init__`
+
+---
+
 ## Version 3.0.0-rc25 (2025-01-08)
 
 ### ✨ Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "params-proto"
-version = "3.0.0-rc25"
+version = "3.0.0-rc26"
 description = "Modern Hyper Parameter Management for Machine Learning"
 authors = [
     { name = "Ge Yang" }

--- a/skill/quick-reference.md
+++ b/skill/quick-reference.md
@@ -8,7 +8,7 @@ description: Cheat sheet for params-proto patterns and syntax
 ## Installation
 
 ```bash
-pip install params-proto==3.0.0-rc25
+pip install params-proto==3.0.0-rc26
 ```
 
 ## Decorators


### PR DESCRIPTION
## Summary
- Automatic type inference for untyped class attributes
- `name = "hello"` treated as `name: str = "hello"`
- `data = None` treated as `data: Any = None` (generic type)
- Untyped attributes now appear in `vars(self)` inside `__post_init__`

## Test plan
- [x] All existing tests pass (294 tests)
- [x] New tests for untyped attributes added
- [x] Tests for None defaults with Any type inference

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **✨ Feature: Automatic type inference for class attributes**
> 
> - Infers types for unannotated class attributes from defaults in `proto` (e.g., `"str"→str`, `42→int`, `None→Any`), skipping methods/descriptors/private names
> - Ensures inferred attributes are included in `__proto_annotations__`, defaults, and appear in `vars(self)` during `__post_init__`; explicit annotations remain unchanged
> 
> **🧪 Tests**
> 
> - Adds tests for `__post_init__` visibility, `vars(self)` contents, untyped inference (including `None→Any`), and an EnvVar inheritance scenario
> 
> **📝 Docs & Version**
> 
> - Updates release notes and quick reference; bumps version to `3.0.0-rc26`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb5e60487fd70305ef2fabd51337fd0c851c708c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->