### PR TITLE
Restricts argparse dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 
 dependencies = [
     "waterbear>=2.6.8",
-    "argparse",
+    "argparse; python_version < '2.7'",  # Built into Python 2.7+ and all Python 3.x
     "argcomplete",
     "expandvars",
     "termcolor",


### PR DESCRIPTION
I ran into some issues with a bazel build because of argparse, which is baked into all python 3.x and >2.7

