### PR TITLE
Release v3.1.0: _dict property and dict() support

### DIFF
--- a/docs/api/proto.md
+++ b/docs/api/proto.md
@@ -315,6 +315,33 @@ See **[Environment Variables Guide](../key_concepts/environment_variables.md)** 
 
 Decorated objects get special attributes:
 
+### `_dict` property
+
+Returns a clean dict of current parameter values (defaults merged with overrides):
+
+```python
+@proto.prefix
+class Config:
+    lr: float = 0.001
+    batch_size: int = 32
+
+Config.lr = 0.01  # Override
+
+Config._dict      # → {'lr': 0.01, 'batch_size': 32}
+dict(Config)      # → {'lr': 0.01, 'batch_size': 32}
+```
+
+Works for both `@proto`/`@proto.prefix` classes and `@proto.cli`/`@proto.prefix` functions:
+
+```python
+@proto.prefix
+def train(lr: float = 0.001, epochs: int = 100):
+    pass
+
+train._dict       # → {'lr': 0.001, 'epochs': 100}
+dict(train)       # → {'lr': 0.001, 'epochs': 100}
+```
+
 ### `__help_str__`
 
 Available on `@proto.cli` decorated functions:

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -2,6 +2,22 @@
 
 This page contains the release history and changelog for params-proto.
 
+## Version 3.1.0 (2025-01-23)
+
+### ✨ Features
+
+- **`_dict` Property and `dict()` Support**: Get a clean dict of parameter values from proto classes and functions
+  - `Config._dict` returns `{'lr': 0.001, 'batch_size': 32}` (defaults merged with overrides)
+  - `dict(Config)` works identically via `__iter__` support
+  - Works for both `@proto`/`@proto.prefix` classes and `@proto.cli`/`@proto.prefix` functions
+
+### 📚 Documentation
+
+- Added `_dict` property documentation to API reference
+- Updated Claude skill references with clean dict examples
+
+---
+
 ## Version 3.0.0 (2025-01-12)
 
 ### ✨ Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "params-proto"
-version = "3.0.0"
+version = "3.1.0"
 description = "Modern Hyper Parameter Management for Machine Learning"
 authors = [
     { name = "Ge Yang" }

--- a/skills/params-proto/SKILL.md
+++ b/skills/params-proto/SKILL.md
@@ -10,14 +10,14 @@ description: |
   (6) Work with Union types for subcommand-like CLI patterns
 ---
 
-# params-proto v3.0.0
+# params-proto v3.1.0
 
 Declarative hyperparameter management for ML experiments with automatic CLI generation.
 
 ## Installation
 
 ```bash
-pip install params-proto==3.0.0
+pip install params-proto==3.1.0
 ```
 
 ## Three Decorators
@@ -166,6 +166,13 @@ def train(
 3. Context manager (`with proto.bind(Config, lr=0.01): ...`)
 4. Environment variables
 5. Default values
+
+## Getting a Clean Dict
+
+```python
+Config._dict      # → {'lr': 0.001, 'batch_size': 32}
+dict(Config)      # → same (works for classes and functions)
+```
 
 ## Reference Files
 

--- a/skills/params-proto/references/cli-and-types.md
+++ b/skills/params-proto/references/cli-and-types.md
@@ -164,6 +164,21 @@ with proto.bind(Training, lr=0.01):
 proto.bind(**{"training.lr": 0.01, "model.name": "vit"})
 ```
 
+### Getting a Clean Dict
+
+```python
+@proto.prefix
+class Config:
+    lr: float = 0.001
+    batch_size: int = 32
+
+Config.lr = 0.01  # Override
+
+# Two equivalent ways to get parameter values
+Config._dict      # → {'lr': 0.01, 'batch_size': 32}
+dict(Config)      # → {'lr': 0.01, 'batch_size': 32}
+```
+
 ### Custom Prefix Name
 
 ```python
@@ -223,6 +238,23 @@ class TrainConfig(BaseConfig):
 
 c = TrainConfig()
 vars(c)  # {'lr': 0.001, 'batch_size': 32, 'epochs': 100}
+```
+
+### Getting a Clean Dict
+
+```python
+@proto
+class Config:
+    lr: float = 0.001
+    batch_size: int = 32
+
+# Class-level: get defaults + overrides
+Config._dict      # → {'lr': 0.001, 'batch_size': 32}
+dict(Config)      # → {'lr': 0.001, 'batch_size': 32}
+
+# Instance-level: use vars()
+c = Config(lr=0.01)
+vars(c)           # → {'lr': 0.01, 'batch_size': 32}
 ```
 
 ### @proto vs @proto.prefix


### PR DESCRIPTION
## Summary
- Add `_dict` property to proto classes and functions for clean dict access
- Add `__iter__` support enabling `dict(Config)` conversion
- Document feature in API reference and Claude skill

## Usage
```python
@proto.prefix
class Config:
    lr: float = 0.001
    batch_size: int = 32

Config._dict      # → {'lr': 0.001, 'batch_size': 32}
dict(Config)      # → same
```